### PR TITLE
Major Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,47 +63,46 @@ Out[7]:
 8  6881378  6553710  7209065  7536743  7274588  6619248
 9  6226030  7209065  6619231  6881380  7274612  3014770
 ```
-
-## Requirements
-- [BCP](https://docs.microsoft.com/en-us/sql/tools/bcp-utility) Utility
-- [SqlCmd](https://docs.microsoft.com/en-us/sql/tools/sqlcmd-utility) Utility
-- Microsoft ODBC Driver for SQL Server (included automatically with the BCP utility)
-- python >= 3.6
-- pandas >= 0.22
-- pyodbc (see section below on creds)
-- sqlalchemy (Pandas requires this for any SQL flavor besides `sqlite`)
-
 ## Benchmarks
 _# TODO_
 
+## Requirements
+### Database
+Any version of Microsoft SQL Server. Can be installed on-prem, in the cloud, on a VM, or the Azure SQL Database/Data Warehouse versions.
+### Python User
+- [BCP](https://docs.microsoft.com/en-us/sql/tools/bcp-utility) Utility
+- [SqlCmd](https://docs.microsoft.com/en-us/sql/tools/sqlcmd-utility) Utility
+- Microsoft ODBC Driver **11, 13, 13.1, or 17** for SQL Server. See the [pyodbc docs](https://github.com/mkleehammer/pyodbc/wiki/Connecting-to-SQL-Server-from-Windows) for details.
+- Python >= 3.6
+- `pandas` >= 0.19
+- `sqlalchemy` >= 1.1.4
+- `pyodbc` as the [supported DBAPI](https://docs.sqlalchemy.org/en/lastest/dialects/mssql.html#dialect-mssql)
+- Windows as the client OS
+  - Linux and MacOS are theoretically compatible, but never tested
+
 ## Installation
-PyPI:
+Source | Command
+:---: | :---:
+PyPI | ```pip install bcpandas``` 
+Conda| ```conda install -c conda-forge bcpandas```
 
-```
-pip install bcpandas
-```
+## Usage
 
-Conda:
-```
-conda install -c conda-forge bcpandas
-```
-
-## Instructions
+### Recommended Usage
+_# TODO_ When to use bcpandas vs. regular pandas.
 
 ### Credential/Connection object
-Bcpandas uses a simple username/password authentication for the BCP and SqlCmd utilities, but it may also require a full `Connection` object like the regular pandas API expects, for:
+Bcpandas uses a simple username/password authentication for the BCP and SqlCmd utilities, but it may also require a full `sqlalchemy.Engine` object like the regular pandas API expects, for:
 1. Creating the SQL table in `to_sql` and `if_exists='replace`, because bcpandas uses some of the internal pandas code to do this
-2. If the bcpandas operation fails, the user can specify that the operation should be retried using the regular pandas methods, which require a full `Connection` object.
+2. If the bcpandas operation fails, the user can specify that the operation should be retried using the regular pandas methods, which require a full `Engine` object.
+_(Planned for in later versions)_
 
 Therefore, the user has 2 choices. 
-1. Pass a full `Connection` object to the bcpandas `SqlCreds` object. Bcpandas will attempt to parse out the server, database, username, and password to pass to the command line utilities. If a DSN is used, this will fail.
-2. Create the bcpandas `SqlCreds` object with just the minimum attributes needed (server, database, username, password), and have bcpandas create a full `Connection` object from this. In this case, bcpandas will use `pyodbc` and `sqlalchemy`, and rely on the Microsoft ODBC Driver for SQL Server.
+1. Pass a full `Engine` object to the bcpandas `SqlCreds` object. Bcpandas will attempt to parse out the server, database, username, and password to pass to the command line utilities. If a DSN is used, this will fail.
+2. Create the bcpandas `SqlCreds` object with just the minimum attributes needed (server, database, username, password), and have bcpandas create a full `Engine` object from this. In this case, bcpandas will use `pyodbc` and `sqlalchemy`, and rely on the Microsoft ODBC Driver for SQL Server.
 
 
-## Recommended Usage
-When to use bcpandas vs. regular pandas. #TODO
-
-## Caveats and Limitations
+## Limitations
 
 Here are some caveats and limitations of bcpandas. Hopefully they will be addressed in future releases
 * In the `to_sql` function:
@@ -113,48 +112,33 @@ Here are some caveats and limitations of bcpandas. Hopefully they will be addres
   * Bcpandas attempts to use a delimiter that is not present in the dataframe. This is because BCP does __not__ ignore delimiter characters when surrounded by quotes, unlike CSVs - see [here](https://docs.microsoft.com/en-us/sql/relational-databases/import-export/specify-field-and-row-terminators-sql-server#characters-supported-as-terminators) in the Microsoft docs. Therefore, if all possible delimiter characters are present in the dataframe and bcpandas cannot find a delimiter to use, it will throw an error.
     * Possible delimiters are specified in `constants.py` .
 * Currently the STDOUT stream from BCP and SqlCmd is not asynchronous.
-* Currently this is being built with Windows in mind. Linux support is definitely easily added, it's just not in the immediate scope of the project yet. PRs are welcome.
 
-## Motivations and Design
-### Overview
-Reading and writing data from pandas DataFrames to/from a SQL database is very slow using the built-in `read_sql` and `to_sql` methods, even with the newly introduced `execute_many` option. For Microsoft SQL Server, a far far faster method is to use the BCP utility provided by Microsoft. This utility is a command line tool that transfers data to/from the database and flat text files.
+## Background
+Reading and writing data from pandas DataFrames to/from a SQL database is very slow using the built-in `read_sql` and `to_sql` methods, even with the newly introduced [`execute_many`](https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-sql-method) option. For Microsoft SQL Server, a far far faster method is to use the BCP utility provided by Microsoft. This utility is a command line tool that transfers data to/from the database and flat text files.
 
 This package is a wrapper for seamlessly using the bcp utility from Python using a pandas DataFrame. Despite the IO hits, the fastest option by far is saving the data to a CSV file in the file system and using the bcp utility to transfer the CSV file to SQL Server. **Best of all, you don't need to know anything about using BCP at all!**
 
 ### Existing Solutions
-
-<table>
-<tr>
-  <td><b>Name</b></td>
-  <td><b>GitHub</b></td>
-  <td><b>PyPI</b></td>
-</tr>
-<tr>
-  <td>bcpy</td>
-  <td>https://github.com/titan550/bcpy</td>
-  <td>https://pypi.org/project/bcpy</td>
-</tr>
-<tr>
-  <td>magical-sqlserver</td>
-  <td>https://github.com/brennoflavio/magical-sqlserver</td>
-  <td>https://pypi.org/project/magical-sqlserver/</td>
-</tr>
-</table>
-
-#### bcpy
-`bcpy` has several flaws:
-* No support for reading from SQL, only writing to SQL
-* A convoluted, overly class-based internal design
-* Scope a bit too broad - deals with pandas as well as flat files
-
-This repository aims to fix and improve on `bcpy` and the above issues by making the design choices described below.
-
 > Much credit is due to `bcpy` for the original idea and for some of the code that was adopted and changed.
+<details>
+  <summary>bcpy</summary>
 
-#### magical-sqlserver
-`magical-sqlserver` is a library to make working with Python and SQL Server very easy. But it doesn't fit what I'm trying to do:
-* No built in support for pandas DataFrame
-* Larger codebase, I'm not fully comfortable with the dependency on the very heavy pymssql
+  [bcpy](https://github.com/titan550/bcpy) has several flaws:
+  * No support for reading from SQL, only writing to SQL
+  * A convoluted, overly class-based internal design
+  * Scope a bit too broad - deals with pandas as well as flat files
+  This repository aims to fix and improve on `bcpy` and the above issues by making the design choices described earlier.
+</details>
+
+
+<details>
+  <summary>magical-sqlserver</summary>
+  
+  [magical-sqlserver](https://github.com/brennoflavio/magical-sqlserver) is a library to make working with Python and SQL Server very easy. But it doesn't fit what I'm trying to do:
+  * No built in support for pandas DataFrame
+  * Larger codebase, I'm not fully comfortable with the dependency on the very heavy pymssql
+
+</details>
 
 ### Design and Scope
 The _**only**_ scope of `bcpandas` is to read and write between a pandas DataFrame and a Microsoft SQL Server database. That's it. We do _**not**_ concern ourselves with reading existing flat files to/from SQL - that introduces _way_ to much complexity in trying to parse and decode the various parts of the file, like delimiters, quote characters, and line endings. Instead, to read/write an exiting flat file, just import it via pandas into a DataFrame, and then use `bcpandas`.
@@ -163,7 +147,6 @@ The big benefit of this is that we get to precicely control all the finicky part
 
 For now, we are using the non-XML BCP format file type. In the future, XML format files may be added.
 
-Both on-prem and cloud (Azure, AWS, etc.) versions of SQL Server are supported.
 
 ## Testing
 Testing uses `pytest`. A local SQL Server is spun up using Docker.

--- a/README.md
+++ b/README.md
@@ -65,27 +65,31 @@ Out[7]:
 ```
 
 ## Requirements
-- BCP Utility
-    - [Windows](https://docs.microsoft.com/en-us/sql/tools/bcp-utility)
-- SqlCmd Utility
-    - [Windows](https://docs.microsoft.com/en-us/sql/tools/sqlcmd-utility)
+- [BCP](https://docs.microsoft.com/en-us/sql/tools/bcp-utility) Utility
+- [SqlCmd](https://docs.microsoft.com/en-us/sql/tools/sqlcmd-utility) Utility
+- Microsoft ODBC Driver for SQL Server (included automatically with the BCP utility)
 - python >= 3.6
-- pandas
+- pandas >= 0.22
+- pyodbc
+- sqlalchemy
 
 ## Benchmarks
 _# TODO_
 
 ## Installation
-You can download and install this package from PyPI
+PyPI:
 
 ```
 pip install bcpandas
 ```
 
-or from conda
+Conda:
 ```
 conda install -c conda-forge bcpandas
 ```
+
+## Recommended Usage
+When to use bcpandas vs. regular pandas. #TODO
 
 ## Caveats and Limitations
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Out[7]:
 - Microsoft ODBC Driver for SQL Server (included automatically with the BCP utility)
 - python >= 3.6
 - pandas >= 0.22
-- pyodbc
-- sqlalchemy
+- pyodbc (see section below on creds)
+- sqlalchemy (Pandas requires this for any SQL flavor besides `sqlite`)
 
 ## Benchmarks
 _# TODO_
@@ -87,6 +87,18 @@ Conda:
 ```
 conda install -c conda-forge bcpandas
 ```
+
+## Instructions
+
+### Credential/Connection object
+Bcpandas uses a simple username/password authentication for the BCP and SqlCmd utilities, but it may also require a full `Connection` object like the regular pandas API expects, for:
+1. Creating the SQL table in `to_sql` and `if_exists='replace`, because bcpandas uses some of the internal pandas code to do this
+2. If the bcpandas operation fails, the user can specify that the operation should be retried using the regular pandas methods, which require a full `Connection` object.
+
+Therefore, the user has 2 choices. 
+1. Pass a full `Connection` object to the bcpandas `SqlCreds` object. Bcpandas will attempt to parse out the server, database, username, and password to pass to the command line utilities. If a DSN is used, this will fail.
+2. Create the bcpandas `SqlCreds` object with just the minimum attributes needed (server, database, username, password), and have bcpandas create a full `Connection` object from this. In this case, bcpandas will use `pyodbc` and `sqlalchemy`, and rely on the Microsoft ODBC Driver for SQL Server.
+
 
 ## Recommended Usage
 When to use bcpandas vs. regular pandas. #TODO

--- a/TODO.MD
+++ b/TODO.MD
@@ -7,7 +7,12 @@
 - [x] Upload to conda-forge
 - [ ] Set up CI/CD
 - [ ] Write more tests
+- [ ] Benchmarks vs. regular pandas methods
 - [x] Find way to automate creation of temp SQL Server db for testing
+- [ ] Build in auto-retry with native pandas methods if BCP method fails
+- [ ] Use pandas internal code to build new SQL tables, instead of just all NVARCHAR
+- [ ] Decide if to assume the user provides their own `conn` connection object for native pandas methods,
+        Or just use the bcpandas SqlCreds
 
 
 ... and of course, anything marked `# TODO` in the code.

--- a/TODO.MD
+++ b/TODO.MD
@@ -2,7 +2,7 @@
 
 - [x] **COME UP WITH A GOOD NAME!** (`pandasql` is already taken in PyPI)
 - [x] Fix up `setup.py`
-- [ ] Stream BCP stdout to logs in real time asynchronously
+- [x] Stream BCP stdout to logs in real time asynchronously
 - [x] Upload to PyPI
 - [x] Upload to conda-forge
 - [ ] Set up CI/CD

--- a/TODO.MD
+++ b/TODO.MD
@@ -11,6 +11,6 @@
 - [x] Find way to automate creation of temp SQL Server db for testing
 - [ ] Build in auto-retry with native pandas methods if BCP method fails
 - [x] Use pandas internal code to build new SQL tables, instead of just all NVARCHAR
-- [ ] Better docs
+- [x] Better docs
 
 ... and of course, anything marked `# TODO` in the code.

--- a/TODO.MD
+++ b/TODO.MD
@@ -10,9 +10,7 @@
 - [ ] Benchmarks vs. regular pandas methods
 - [x] Find way to automate creation of temp SQL Server db for testing
 - [ ] Build in auto-retry with native pandas methods if BCP method fails
-- [ ] Use pandas internal code to build new SQL tables, instead of just all NVARCHAR
-- [ ] Decide if to assume the user provides their own `conn` connection object for native pandas methods,
-        Or just use the bcpandas SqlCreds
-
+- [x] Use pandas internal code to build new SQL tables, instead of just all NVARCHAR
+- [ ] Better docs
 
 ... and of course, anything marked `# TODO` in the code.

--- a/bcpandas/__init__.py
+++ b/bcpandas/__init__.py
@@ -1,7 +1,7 @@
 from .main import to_sql, read_sql, SqlCreds
 from .utils import bcp, sqlcmd
 
-import subprocess
+from subprocess import run, DEVNULL
 import warnings
 
 name = "bcpandas"
@@ -12,10 +12,10 @@ __version__ = "0.1.0"
 cmds = [["bcp", "-v"], ["sqlcmd", "-?"]]
 for cmd in cmds:
     try:
-        subprocess.run(cmd)
+        run(cmd, stdout=DEVNULL, stderr=DEVNULL)
     except FileNotFoundError:
         warnings.warn(
             f"{cmd[0].upper()} utility not installed or not found in PATH, bcpandas will not work!"
         )
 
-del subprocess, warnings, cmd
+del run, DEVNULL, warnings, cmd

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -180,7 +180,6 @@ def build_format_file(df, delimiter):
 
     # TODO add params/options to control:
     #   - the char type (not just SQLCHAR),
-    #   - the ability to skip destination columns
 
     Parameters
     ----------
@@ -213,37 +212,6 @@ def build_format_file(df, delimiter):
     # FYI very important to surround the Terminator with quotes, otherwise BCP fails with:
     # "Unexpected EOF encountered in BCP data-file". Hugely frustrating bug.
     return format_file_str
-
-
-def _get_sql_create_statement(df, table_name, schema="dbo"):
-    """
-    Creates a SQL drop and re-create statement corresponding to the columns list of the object.
-    
-    Parameters
-    -------------
-    df : pandas DataFrame
-    table_name : str
-        name of the new table
-    
-    Returns
-    -------------
-    SQL code to create the table
-    """
-    sql_cols = ",".join(map(lambda x: f"[{x}] nvarchar(max)", df.columns))
-    sql_command = (
-        f"if object_id('[dbo].[{table_name}]', 'U') "
-        f"is not null drop table [dbo].[{table_name}];"
-        f"create table [dbo].[{table_name}] ({sql_cols});"
-    )
-    return sql_command
-
-
-def parse_subprocess_error(result):
-    msg = {}
-    for item in ["args", "returncode", "stdout", "stderr"]:
-        _i = getattr(result, item)
-        msg[item] = _i.decode() if isinstance(_i, bytes) else _i
-    return msg
 
 
 def run_cmd(cmd, live_mode=True):

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -225,7 +225,7 @@ def build_format_file(df, delimiter):
                 str(0),  # Host file data length
                 f'"{_escape(_delim)}"',  # Terminator (see note below)
                 str(col_num),  # Server column order
-                col_name,  # Server column name, optional as long as not blank
+                str(col_name),  # Server column name, optional as long as not blank
                 sql_collation,  # Column collation
                 "\n",
             ]

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -10,6 +10,7 @@ import os
 import random
 import string
 import subprocess
+from subprocess import Popen, PIPE
 import tempfile
 from io import StringIO
 
@@ -95,17 +96,11 @@ def bcp(
         ]
 
     # execute
-    # TODO better logging and error handling the return stream
     bcp_command_log = [c if c != creds.password else "[REDACTED]" for c in bcp_command]
     logger.info(f"Executing BCP command now... \nBCP command is: {bcp_command_log}")
-    result = subprocess.run(
-        bcp_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8"
-    )
-    logger.debug(result.stdout)
-    if result.returncode:
-        logger.error(result.stdout)
-        msg = parse_subprocess_error(result)
-        raise BCPandasException(f"Bcp command failed. Details:\n{msg}")
+    ret_code = run_cmd(bcp_command)
+    if ret_code:
+        raise BCPandasException(f"Bcp command failed with exit code {ret_code}")
 
 
 def sqlcmd(creds, command):
@@ -144,27 +139,13 @@ def sqlcmd(creds, command):
     )
 
     # execute
-    # TODO better logging and error handling the return stream
     sqlcmd_command_log = [c if c != creds.password else "[REDACTED]" for c in sqlcmd_command]
     logger.info(f"Executing SqlCmd command now... \nSqlCmd command is: {sqlcmd_command_log}")
-    result = subprocess.run(
-        sqlcmd_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8"
-    )
-    logger.debug(result.stdout)
-    if result.returncode:
-        logger.error(result.stdout)
-        msg = parse_subprocess_error(result)
-        raise BCPandasException(f"SqlCmd command failed. Details:\n{msg}")
-
-    output = StringIO(result.stdout)
-    first_line_output = output.readline().strip()
-    if first_line_output == "":
-        header = None
-    else:
-        header = "infer"
-    output.seek(0)
+    ret_code, output = run_cmd(sqlcmd_command, live_mode=False)
+    if ret_code:
+        raise BCPandasException(f"SqlCmd command failed with exit code {ret_code}")
     try:
-        result = pd.read_csv(filepath_or_buffer=output, skiprows=[1], header=header)
+        result = pd.read_csv(filepath_or_buffer=output, skiprows=[1], header="infer")
     except pd.errors.EmptyDataError:
         result = None
     return result
@@ -265,3 +246,42 @@ def parse_subprocess_error(result):
         _i = getattr(result, item)
         msg[item] = _i.decode() if isinstance(_i, bytes) else _i
     return msg
+
+
+def run_cmd(cmd, live_mode=True):
+    """
+    Runs the given command. 
+    
+    If live_mode is enabled, prints STDOUT in real time, 
+    prints STDERR when command is complete, and logs both STDOUT and STDERR.
+    Otherwise, just runs the command, prints STDERR, and returns both the exit code and STDOUT
+
+    Paramters
+    ---------
+    cmd : list of str
+        The command to run, to be submitted to `subprocess.Popen()`
+    live_mode : bool, default True
+        If to enable live_mode
+
+    Returns
+    -------
+    The exit code of the command, and STDOUT if live_mode is enabled
+    """
+    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, encoding="utf-8", errors="utf-8")
+    if live_mode:
+        # live stream STDOUT
+        while True:
+            outs = proc.stdout.readline()
+            if outs:
+                print(outs, end="")
+                logger.info(outs)
+            if proc.poll() is not None and outs == "":
+                break
+    errs = proc.stderr.readlines()
+    if errs:
+        print(errs, end="")
+        logger.error(errs)
+    if live_mode:
+        return proc.returncode
+    else:
+        return proc.returncode, proc.stdout

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -9,10 +9,8 @@ import logging
 import os
 import random
 import string
-import subprocess
 from subprocess import Popen, PIPE
 import tempfile
-from io import StringIO
 
 import pandas as pd
 

--- a/dist.json
+++ b/dist.json
@@ -8,9 +8,9 @@
     "author": "Josh Dimarsky",
     "python_version": ">=3.6",
     "dependencies": [
-        "pandas>=0.22",
+        "pandas>=0.19",
         "pyodbc",
-        "sqlalchemy"
+        "sqlalchemy>=1.1.4"
     ],
     "dependencies_test": [
         "pytest",

--- a/dist.json
+++ b/dist.json
@@ -8,11 +8,17 @@
     "author": "Josh Dimarsky",
     "python_version": ">=3.6",
     "dependencies": [
-        "pandas>=0.22"
+        "pandas>=0.22",
+        "pyodbc",
+        "sqlalchemy"
     ],
     "dependencies_test": [
         "pytest",
-        "pyodbc",
-        "sqlalchemy"
+        "pytest-benchmark"
+    ],
+    "dependencies_dev": [
+        "black",
+        "pre-commit",
+        "spyder-kernels=0.*"
     ]
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-pytest
-pyodbc
-sqlalchemy
-black
-pre-commit
-spyder-kernels=0.*

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -57,7 +57,17 @@ def docker_db():
 
 @pytest.fixture(scope="session")
 def sql_creds():
-    creds = SqlCreds(server="127.0.0.1,1433", database=_db_name, username="sa", password=_pwd)
+    creds = SqlCreds(
+        server="127.0.0.1,1433",
+        database=_db_name,
+        username="sa",
+        password=_pwd,
+        # odbc_driver_kwargs_dict={
+        #     "Encrypt": '"yes"',
+        #     "TrustServerCertificate": '"yes"',
+        #     "Connection Timeout": 30
+        # }
+    )
     return creds
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -22,10 +22,10 @@ from bcpandas.utils import _get_sql_create_statement
 
 _pwd = "MyBigSQLPassword!!!"
 _db_name = "db_bcpandas"
-_docker_startup = 10  # seconds to wait to give the container time to start
+_docker_startup = 15  # seconds to wait to give the container time to start
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def docker_db():
     _name = "bcpandas-container"
     cmd_start_container = [
@@ -55,23 +55,20 @@ def docker_db():
     print("all done!")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def sql_creds():
     creds = SqlCreds(
         server="127.0.0.1,1433",
         database=_db_name,
         username="sa",
         password=_pwd,
-        # odbc_driver_kwargs_dict={
-        #     "Encrypt": '"yes"',
-        #     "TrustServerCertificate": '"yes"',
-        #     "Connection Timeout": 30
-        # }
+        # Encrypt= "yes",
+        # TrustServerCertificate="yes",
     )
     return creds
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def setup_db_tables(docker_db):
     creds_master = SqlCreds(
         server="127.0.0.1,1433", database="master", username="sa", password=_pwd
@@ -79,7 +76,7 @@ def setup_db_tables(docker_db):
     sqlcmd(creds_master, f"CREATE DATABASE {_db_name}")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def pyodbc_creds(docker_db):
 
     db_url = (

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Aug  3 23:36:07 2019
+
+@author: ydima
+"""
+
+import subprocess
+import time
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from bcpandas import SqlCreds, bcp, read_sql, sqlcmd, to_sql
+
+_pwd = "MyBigSQLPassword!!!"
+_db_name = "db_bcpandas"
+_docker_startup = 10  # seconds to wait to give the container time to start
+
+
+@pytest.fixture(scope="module")
+def docker_db():
+    _name = "bcpandas-container-perf"
+    cmd_start_container = [
+        "docker",
+        "run",
+        "-d",
+        "-e",
+        "ACCEPT_EULA=Y",
+        "-e",
+        f"SA_PASSWORD={_pwd}",
+        "-e",
+        "MSSQL_PID=Express",
+        "-p",
+        "1433:1433",
+        "--name",
+        _name,
+        "mcr.microsoft.com/mssql/server:2017-latest",
+    ]
+    subprocess.run(cmd_start_container)
+    time.sleep(_docker_startup)
+    print("successfully started DB in docker...")
+    yield
+    print("Stopping container")
+    subprocess.run(["docker", "stop", _name])
+    print("Deleting container")
+    subprocess.run(["docker", "rm", _name])
+    print("all done!")
+
+
+@pytest.fixture(scope="module")
+def creds_and_setup(docker_db):
+    # creds
+    creds = SqlCreds(server="127.0.0.1,1433", database=_db_name, username="sa", password=_pwd)
+
+    # setup
+    creds_master = SqlCreds(
+        server="127.0.0.1,1433", database="master", username="sa", password=_pwd
+    )
+    sqlcmd(creds_master, f"CREATE DATABASE {_db_name}")
+
+    return creds
+
+
+@pytest.fixture(scope="module")
+def data():
+
+    from pandas.util import testing as pdt
+    import random
+
+    dikt = {}
+    num_cols = 6
+    num_rows = 100000
+
+    dikt["ints"] = pdt.makeCustomDataframe(
+        num_rows,
+        num_cols,
+        r_idx_type="i",
+        data_gen_f=lambda r, c: np.random.randint(-250000, 250000),
+    )
+
+    dikt["floats"] = dikt["ints"] / 100000
+
+    dikt["strings"] = pdt.makeCustomDataframe(num_rows, num_cols, r_idx_type="i")
+
+    rand_str = ["Alpha", "Bravo", "Charlie", "Delta," "Echo", "Foxtrot"]
+    rand_int = list(np.random.randint(-5, 5, size=(10)))
+    rand_float = list(np.random.rand(10))
+
+    dikt["mixed_on_rows"] = pdt.makeCustomDataframe(
+        num_rows,
+        num_cols,
+        r_idx_type="i",
+        data_gen_f=lambda r, c: random.choice(rand_str + rand_int + rand_float),
+    )
+
+    def _func_m(r, c):
+        if c in (0, 3):
+            return random.choice(rand_str)
+        elif c in (1, 4):
+            return random.choice(rand_int)
+        elif c in (2, 5):
+            return random.choice(rand_float)
+
+    dikt["mixed_on_cols"] = pdt.makeCustomDataframe(
+        num_rows, num_cols, r_idx_type="i", data_gen_f=_func_m
+    )
+
+    return dikt
+
+
+def test_tosql_ints(creds_and_setup, data):
+    pass
+
+
+def test_readsql_bcp_ints(creds_and_setup, data, benchmark):
+    # setup
+    table_name = "perf_ints"
+    to_sql(
+        data["ints"], table_name=table_name, creds=creds_and_setup, index=False, if_exists="replace"
+    )
+
+    # benchmark!
+    benchmark(read_sql, table_name="perf_ints", creds=creds_and_setup)
+
+
+def test_readsql_pd_ints(creds_and_setup, data, benchmark):
+    # setup
+    table_name = "perf_ints"
+    to_sql(
+        data["ints"], table_name=table_name, creds=creds_and_setup, index=False, if_exists="replace"
+    )
+
+    # benchmark!
+    benchmark(pd.read_sql_table, table_name=table_name, con=creds_and_setup.engine)


### PR DESCRIPTION
- Better docs
- Suppressed output from command line tools in `__init__.py`
- In `to_sql` with `if_exists='replace'`, now uses `pandas`'s own internal code to create the new SQL table from the dataframe, including preserving the column types and other schema information. Big improvement over the default NVARCHAR columns that was until now.
- `SqlCreds` now creates a `sqlalchemy.Engine`, and can also be created from one.
- `bcp` now outputs STDOUT in real time, instead of waiting until the process is complete
- Bug fix in creating BCP format file if the column name was not a string
- Started working on benchmark tests, using `pytest-benchmark`
- Added dependencies to support the `sqlalchemy.Engine` object