### PR TITLE
Resolved Windows Auth issue and added Port parameter

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Test with pytest
       shell: bash -l {0}
       run: |
-        pytest -x --cov-report=xml --mssql-docker-image ${{ matrix.mssql_image }} bcpandas/tests/test_to_sql.py
+        pytest -x --cov-report=xml --mssql-docker-image ${{ matrix.mssql_image }} bcpandas/tests/
     
     - name: Upload Codecov.io report (Linux)
       if: ${{ runner.os == 'Linux'}}

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -77,19 +77,19 @@ class SqlCreds:
         else:
             port_str = ""
 
+        db_url = (
+            f"Driver={self.driver};Server=tcp:{self.server}{port_str};Database={self.database};"
+        )
         if username and password:
             self.username = username
             self.password = password
             self.with_krb_auth = False
-            db_url = (
-                f"Driver={self.driver};Server=tcp:{self.server}{port_str};Database={self.database};"
-                f"UID={username};PWD={password}"
-            )
+            db_url += f"UID={username};PWD={password}"
         else:
             self.username = ""
             self.password = ""
             self.with_krb_auth = True
-            db_url = f"Driver={self.driver};Server=tcp:{self.server}{port_str};Database={self.database};Trusted_Connection=yes;"
+            db_url += "Trusted_Connection=yes;"
 
         logger.info(f"Created creds:\t{self}")
 
@@ -125,14 +125,13 @@ class SqlCreds:
 
             if "," in conn_dict["Server"]:
                 conn_dict["port"] = int(conn_dict["Server"].split(",")[1])
-                
+
             sql_creds = cls(
                 server=conn_dict["Server"].replace("tcp:", "").split(",")[0],
                 database=conn_dict["Database"],
                 username=conn_dict.get("UID", None),
                 password=conn_dict.get("PWD", None),
                 port=conn_dict.get("port", None),
-
             )
 
             # add Engine object as attribute

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -62,24 +62,38 @@ class SqlCreds:
         username: str = None,
         password: str = None,
         driver_version: int = 17,
+        port: int = 1433,
         odbc_kwargs: Optional[Dict[str, Union[str, int]]] = None,
     ):
         self.server = server
         self.database = database
+        self.port = port
+
+        self.driver = f"{{ODBC Driver {driver_version} for SQL Server}}"
+
+        # Append a comma for use in connection strings (optionally blank)
+        if port:
+            port_str = f",{self.port}"
+        else:
+            port_str = ""
+
         if username and password:
             self.username = username
             self.password = password
             self.with_krb_auth = False
+            db_url = (
+                f"Driver={self.driver};Server=tcp:{self.server}{port_str};Database={self.database};"
+                f"UID={username};PWD={password}"
+            )
         else:
+            self.username = None
+            self.password = None
             self.with_krb_auth = True
+            db_url = f"Driver={self.driver};Server=tcp:{self.server}{port_str};Database={self.database};Trusted_Connection=yes;"
+
         logger.info(f"Created creds:\t{self}")
 
         # construct the engine for sqlalchemy
-        driver = f"{{ODBC Driver {driver_version} for SQL Server}}"
-        db_url = (
-            f"Driver={driver};Server=tcp:{self.server},1433;Database={self.database};"
-            f"UID={self.username};PWD={self.password}"
-        )
         if odbc_kwargs:
             db_url += ";".join(f"{k}={v}" for k, v in odbc_kwargs.items())
         conn_string = f"mssql+pyodbc:///?odbc_connect={quote_plus(db_url)}"
@@ -109,12 +123,18 @@ class SqlCreds:
             # convert into dict
             conn_dict = {x.split("=")[0]: x.split("=")[1] for x in conn_url if "=" in x}
 
+            if "," in conn_dict["Server"]:
+                conn_dict["port"] = int(conn_dict["Server"].split(",")[1])
+                
             sql_creds = cls(
-                server=conn_dict["Server"].replace("tcp:", "").replace(",1433", ""),
+                server=conn_dict["Server"].replace("tcp:", "").split(",")[0],
                 database=conn_dict["Database"],
-                username=conn_dict["UID"],
-                password=conn_dict["PWD"],
+                username=conn_dict.get("UID", None),
+                password=conn_dict.get("PWD", None),
+                port=conn_dict.get("port", None),
+
             )
+
             # add Engine object as attribute
             sql_creds.engine = engine
             return sql_creds

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -59,8 +59,8 @@ class SqlCreds:
         self,
         server: str,
         database: str,
-        username: str = None,
-        password: str = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
         driver_version: int = 17,
         port: int = 1433,
         odbc_kwargs: Optional[Dict[str, Union[str, int]]] = None,
@@ -86,8 +86,8 @@ class SqlCreds:
                 f"UID={username};PWD={password}"
             )
         else:
-            self.username = None
-            self.password = None
+            self.username = ""
+            self.password = ""
             self.with_krb_auth = True
             db_url = f"Driver={self.driver};Server=tcp:{self.server}{port_str};Database={self.database};Trusted_Connection=yes;"
 

--- a/bcpandas/tests/test_sqlcreds.py
+++ b/bcpandas/tests/test_sqlcreds.py
@@ -59,8 +59,8 @@ def test_sql_creds_for_windows_auth():
     creds = SqlCreds(server="test_server", database="test_database", driver_version=99,)
     assert creds.server == "test_server"
     assert creds.database == "test_database"
-    assert creds.username is None
-    assert creds.password is None
+    assert creds.username == ""
+    assert creds.password == ""
     assert creds.port == 1433
     assert creds.with_krb_auth is True
     assert isinstance(creds.engine, engine.Connectable)
@@ -186,8 +186,8 @@ def test_sql_creds_from_sqlalchemy_windows_auth():
     creds = SqlCreds.from_engine(mssql_engine)
     assert creds.server == "test_server"
     assert creds.database == "test_database"
-    assert creds.username is None
-    assert creds.password is None
+    assert creds.username == ""
+    assert creds.password == ""
     assert creds.port == 1433
     assert creds.with_krb_auth is True
     assert isinstance(creds.engine, engine.Connectable)
@@ -238,8 +238,8 @@ def test_sql_creds_from_sqlalchemy_windows_auth_non_default_port():
     creds = SqlCreds.from_engine(mssql_engine)
     assert creds.server == "test_server"
     assert creds.database == "test_database"
-    assert creds.username is None
-    assert creds.password is None
+    assert creds.username == ""
+    assert creds.password == ""
     assert creds.port == 9999
     assert creds.with_krb_auth is True
     assert isinstance(creds.engine, engine.Connectable)
@@ -284,8 +284,8 @@ def test_sql_creds_from_sqlalchemy_windows_auth_blank_port():
     creds = SqlCreds.from_engine(mssql_engine)
     assert creds.server == "test_server"
     assert creds.database == "test_database"
-    assert creds.username is None
-    assert creds.password is None
+    assert creds.username == ""
+    assert creds.password == ""
     assert creds.port is None
     assert creds.with_krb_auth is True
     assert isinstance(creds.engine, engine.Connectable)

--- a/bcpandas/tests/test_sqlcreds.py
+++ b/bcpandas/tests/test_sqlcreds.py
@@ -59,8 +59,8 @@ def test_sql_creds_for_windows_auth():
     creds = SqlCreds(server="test_server", database="test_database", driver_version=99,)
     assert creds.server == "test_server"
     assert creds.database == "test_database"
-    assert creds.username == None
-    assert creds.password == None
+    assert creds.username is None
+    assert creds.password is None
     assert creds.port == 1433
     assert creds.with_krb_auth is True
     assert isinstance(creds.engine, engine.Connectable)
@@ -122,7 +122,7 @@ def test_sql_creds_for_username_password_blank_port():
         driver_version=99,
         port=None,
     )
-    assert creds.port == None
+    assert creds.port is None
     assert str(creds.engine.url) == (
         "mssql+pyodbc:///?odbc_connect="
         "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server;Database=test_database;"
@@ -138,7 +138,7 @@ def test_sql_creds_for_windows_auth_blank_port():
     * Use blank port
     """
     creds = SqlCreds(server="test_server", database="test_database", driver_version=99, port=None,)
-    assert creds.port == None
+    assert creds.port is None
     assert str(creds.engine.url) == (
         "mssql+pyodbc:///?odbc_connect="
         "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server;Database=test_database;Trusted_Connection=yes;"
@@ -186,8 +186,8 @@ def test_sql_creds_from_sqlalchemy_windows_auth():
     creds = SqlCreds.from_engine(mssql_engine)
     assert creds.server == "test_server"
     assert creds.database == "test_database"
-    assert creds.username == None
-    assert creds.password == None
+    assert creds.username is None
+    assert creds.password is None
     assert creds.port == 1433
     assert creds.with_krb_auth is True
     assert isinstance(creds.engine, engine.Connectable)
@@ -238,8 +238,8 @@ def test_sql_creds_from_sqlalchemy_windows_auth_non_default_port():
     creds = SqlCreds.from_engine(mssql_engine)
     assert creds.server == "test_server"
     assert creds.database == "test_database"
-    assert creds.username == None
-    assert creds.password == None
+    assert creds.username is None
+    assert creds.password is None
     assert creds.port == 9999
     assert creds.with_krb_auth is True
     assert isinstance(creds.engine, engine.Connectable)
@@ -263,7 +263,7 @@ def test_sql_creds_from_sqlalchemy_blank_port():
     assert creds.database == "test_database"
     assert creds.username == "test_user"
     assert creds.password == "test_password"
-    assert creds.port == None
+    assert creds.port is None
     assert creds.with_krb_auth is False
     assert isinstance(creds.engine, engine.Connectable)
     assert str(creds.engine.url) == (
@@ -284,9 +284,9 @@ def test_sql_creds_from_sqlalchemy_windows_auth_blank_port():
     creds = SqlCreds.from_engine(mssql_engine)
     assert creds.server == "test_server"
     assert creds.database == "test_database"
-    assert creds.username == None
-    assert creds.password == None
-    assert creds.port == None
+    assert creds.username is None
+    assert creds.password is None
+    assert creds.port is None
     assert creds.with_krb_auth is True
     assert isinstance(creds.engine, engine.Connectable)
     assert str(creds.engine.url) == (

--- a/bcpandas/tests/test_sqlcreds.py
+++ b/bcpandas/tests/test_sqlcreds.py
@@ -1,0 +1,339 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sat June 27 2020
+
+@author: sstride
+
+Tests included in this file:
+    - Test instantiation of SqlCreds with username/password or without (Windows auth)
+    - Test instantiation of SqlCreds with/without username/password with non-default port (9999)
+    - Test instantiation of SqlCreds with/without username/password with no port specified
+    - Test creation of SqlCreds from SqlAlchemy with/without username/password
+    - Test creation of SqlCreds from SqlAlchemy with/without username/password with non-default port (9999)
+    - Test creation of SqlCreds from SqlAlchemy with/without username/password with no port specified
+    - Test connection to docker instance with username/password
+    - Test connection to docker instance with username/password interpretted from SqlAlchemy Engine
+
+Not included (yet):
+    - *Actually connecting* to SQL Server with Windows Auth
+
+# TODO creating SqlCreds from SqlAlchemy engine case insensitivity
+"""
+
+import urllib
+import pytest
+import pandas as pd
+from bcpandas import SqlCreds
+from sqlalchemy import engine, create_engine
+
+
+def test_sql_creds_for_username_password():
+    """
+    Tests that the SqlCreds object can be created with Username and Password (SQL Auth)
+    """
+    creds = SqlCreds(
+        server="test_server",
+        database="test_database",
+        username="test_user",
+        password="test_password",
+        driver_version=99,
+    )
+    assert creds.server == "test_server"
+    assert creds.database == "test_database"
+    assert creds.username == "test_user"
+    assert creds.password == "test_password"
+    assert creds.port == 1433
+    assert creds.with_krb_auth is False
+    assert isinstance(creds.engine, engine.Connectable)
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,1433;Database=test_database;"
+        "UID=test_user;PWD=test_password"
+    )
+
+
+def test_sql_creds_for_windows_auth():
+    """
+    Tests that the SqlCreds object can be created without Username and Password (Windows Auth)
+    """
+    creds = SqlCreds(server="test_server", database="test_database", driver_version=99,)
+    assert creds.server == "test_server"
+    assert creds.database == "test_database"
+    assert creds.username == None
+    assert creds.password == None
+    assert creds.port == 1433
+    assert creds.with_krb_auth is True
+    assert isinstance(creds.engine, engine.Connectable)
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,1433;Database=test_database;Trusted_Connection=yes;"
+    )
+    # n.b. this is automatically appending tcp: and port 1433
+
+
+def test_sql_creds_for_username_password_non_default_port():
+    """
+    Tests that the SqlCreds object can be created with Username and Password (SQL Auth)
+    """
+    creds = SqlCreds(
+        server="test_server",
+        database="test_database",
+        username="test_user",
+        password="test_password",
+        driver_version=99,
+        port=9999,
+    )
+    assert creds.port == 9999
+    assert creds.with_krb_auth is False
+    assert isinstance(creds.engine, engine.Connectable)
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,9999;Database=test_database;"
+        "UID=test_user;PWD=test_password"
+    )
+
+
+def test_sql_creds_for_windows_auth_non_default_port():
+    """
+    Tests that the SqlCreds object can be created without Username and Password (Windows Auth)
+    """
+    creds = SqlCreds(server="test_server", database="test_database", driver_version=99, port=9999,)
+    assert creds.port == 9999
+    assert creds.with_krb_auth is True
+    assert isinstance(creds.engine, engine.Connectable)
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,9999;Database=test_database;Trusted_Connection=yes;"
+    )
+
+
+def test_sql_creds_for_username_password_blank_port():
+    """
+    Tests that the SqlCreds object can be created with Username and Password (SQL Auth) and blank Port
+    
+    * With Username and Password
+    * Use blank port
+    """
+    creds = SqlCreds(
+        server="test_server",
+        database="test_database",
+        username="test_user",
+        password="test_password",
+        driver_version=99,
+        port=None,
+    )
+    assert creds.port == None
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server;Database=test_database;"
+        "UID=test_user;PWD=test_password"
+    )
+
+
+def test_sql_creds_for_windows_auth_blank_port():
+    """
+    Tests that the SqlCreds object can be created
+    
+    * Without Username and Password (Windows Auth)
+    * Use blank port
+    """
+    creds = SqlCreds(server="test_server", database="test_database", driver_version=99, port=None,)
+    assert creds.port == None
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server;Database=test_database;Trusted_Connection=yes;"
+    )
+
+
+def test_sql_creds_from_sqlalchemy():
+    """
+    Tests that the SqlCreds object can be created from a SqlAlchemy engine
+    
+    * With Username and Password
+    * Use default port (1433)
+    """
+    params = urllib.parse.quote_plus(
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,1433;Database=test_database;"
+        "UID=test_user;PWD=test_password"
+    )
+    mssql_engine = create_engine("mssql+pyodbc:///?odbc_connect=%s" % params)
+    creds = SqlCreds.from_engine(mssql_engine)
+    assert creds.server == "test_server"
+    assert creds.database == "test_database"
+    assert creds.username == "test_user"
+    assert creds.password == "test_password"
+    assert creds.port == 1433
+    assert creds.with_krb_auth is False
+    assert isinstance(creds.engine, engine.Connectable)
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        + "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,1433;Database=test_database;"
+        + "UID=test_user;PWD=test_password"
+    )
+
+
+def test_sql_creds_from_sqlalchemy_windows_auth():
+    """
+    Tests that the SqlCreds object can be created from a SqlAlchemy engine
+    
+    * Without Username and Password
+    * Use default port (1433)
+    """
+    params = urllib.parse.quote_plus(
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,1433;Database=test_database"
+    )
+    mssql_engine = create_engine("mssql+pyodbc:///?odbc_connect=%s" % params)
+    creds = SqlCreds.from_engine(mssql_engine)
+    assert creds.server == "test_server"
+    assert creds.database == "test_database"
+    assert creds.username == None
+    assert creds.password == None
+    assert creds.port == 1433
+    assert creds.with_krb_auth is True
+    assert isinstance(creds.engine, engine.Connectable)
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        + "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,1433;Database=test_database"
+    )
+
+
+def test_sql_creds_from_sqlalchemy_non_default_port():
+    """
+    Tests that the SqlCreds object can be created from a SqlAlchemy engine
+
+    * With Username and Password
+    * Non-Default Port specified (9999)
+    """
+    params = urllib.parse.quote_plus(
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,9999;Database=test_database;"
+        "UID=test_user;PWD=test_password"
+    )
+    mssql_engine = create_engine("mssql+pyodbc:///?odbc_connect=%s" % params)
+    creds = SqlCreds.from_engine(mssql_engine)
+    assert creds.server == "test_server"
+    assert creds.database == "test_database"
+    assert creds.username == "test_user"
+    assert creds.password == "test_password"
+    assert creds.port == 9999
+    assert creds.with_krb_auth is False
+    assert isinstance(creds.engine, engine.Connectable)
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        + "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,9999;Database=test_database;"
+        + "UID=test_user;PWD=test_password"
+    )
+
+
+def test_sql_creds_from_sqlalchemy_windows_auth_non_default_port():
+    """
+    Tests that the SqlCreds object can be created from a SqlAlchemy engine
+    
+    * Without Username and Password
+    * Non-Default Port specifed (9999)
+    """
+    params = urllib.parse.quote_plus(
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,9999;Database=test_database"
+    )
+    mssql_engine = create_engine("mssql+pyodbc:///?odbc_connect=%s" % params)
+    creds = SqlCreds.from_engine(mssql_engine)
+    assert creds.server == "test_server"
+    assert creds.database == "test_database"
+    assert creds.username == None
+    assert creds.password == None
+    assert creds.port == 9999
+    assert creds.with_krb_auth is True
+    assert isinstance(creds.engine, engine.Connectable)
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        + "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server,9999;Database=test_database"
+    )
+
+
+def test_sql_creds_from_sqlalchemy_blank_port():
+    """
+    Tests that the SqlCreds object can be created from a SqlAlchemy engine with no Port specified
+    """
+    params = urllib.parse.quote_plus(
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server;Database=test_database;"
+        "UID=test_user;PWD=test_password"
+    )
+    mssql_engine = create_engine("mssql+pyodbc:///?odbc_connect=%s" % params)
+    creds = SqlCreds.from_engine(mssql_engine)
+    assert creds.server == "test_server"
+    assert creds.database == "test_database"
+    assert creds.username == "test_user"
+    assert creds.password == "test_password"
+    assert creds.port == None
+    assert creds.with_krb_auth is False
+    assert isinstance(creds.engine, engine.Connectable)
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        + "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server;Database=test_database;"
+        + "UID=test_user;PWD=test_password"
+    )
+
+
+def test_sql_creds_from_sqlalchemy_windows_auth_blank_port():
+    """
+    Tests that the SqlCreds object can be created from a SqlAlchemy engine - without Username, Password or Port
+    """
+    params = urllib.parse.quote_plus(
+        "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server;Database=test_database"
+    )
+    mssql_engine = create_engine("mssql+pyodbc:///?odbc_connect=%s" % params)
+    creds = SqlCreds.from_engine(mssql_engine)
+    assert creds.server == "test_server"
+    assert creds.database == "test_database"
+    assert creds.username == None
+    assert creds.password == None
+    assert creds.port == None
+    assert creds.with_krb_auth is True
+    assert isinstance(creds.engine, engine.Connectable)
+    assert str(creds.engine.url) == (
+        "mssql+pyodbc:///?odbc_connect="
+        + "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server;Database=test_database"
+    )
+
+
+@pytest.mark.usefixtures("database")
+def test_sqlcreds_connection(sql_creds):
+    """
+    Simple test to ensure that the generated creds can connect to the database
+
+    The sql_creds fixture necessarily uses username and password (no Windows auth)
+    """
+
+    df = pd.read_sql(con=sql_creds.engine, sql="SELECT TOP 1 * FROM sys.objects")
+
+    assert df.shape[0] == 1
+
+
+@pytest.mark.usefixtures("database")
+def test_sqlcreds_connection_from_sqlalchemy(sql_creds):
+    """
+    Simple test to ensure that the generated creds can connect to the database by
+    interpretting the connection from a SQLAlchemy engine
+
+    The sql_creds fixture necessarily uses username and password (no Windows auth)
+    """
+
+    # Create an actual SQL Alchemy connection
+    # n.b. Keys are case sensitive
+    conn_str = (
+        f"DRIVER={sql_creds.driver};"
+        f"Server={sql_creds.server};"
+        f"Database={sql_creds.database};"
+        f"UID={sql_creds.username};"
+        f"PWD={sql_creds.password};"
+    )
+    params = urllib.parse.quote_plus(conn_str)
+
+    mssql_engine = create_engine("mssql+pyodbc:///?odbc_connect=%s" % params)
+
+    # Re-interpret using SqlCreds
+    test_engine = SqlCreds.from_engine(mssql_engine).engine
+
+    # Check the SqlCreds version works
+    df = pd.read_sql(con=test_engine, sql="SELECT TOP 1 * FROM sys.objects")
+
+    assert df.shape[0] == 1


### PR DESCRIPTION
This PR covers two items:

## 1. Fixes issue with Windows Auth

Windows Auth now works as expected and no longer throws an error when establishing a connection without `username` and `password` specified

````python
creds = SqlCreds(server="localhost\\named_instance", database="db_name")
````

This also works when extracting a connection from a SqlAlchemy engine provided that:

1. The connection uses the urllib method specified in the [sqlalchemy docs](https://docs.sqlalchemy.org/en/13/dialects/mssql.html#module-sqlalchemy.dialects.mssql.pyodbc) (it looks for "odbc_connect")
2. The definition of Server, Database, UID and Password are case-sensitive and must be specified correctly (possible future work item  to make them case-insensitive)

## 2. Added `port` parameter to SqlCreds

The `port` parameter value defaults to 1433 (as per the existing setup and test suite) however now allows connections to non-default ports.

This also accepts an input value of "None" e.g. for named pipe connections.

````python
# non-default port 12345
creds = SqlCreds(server="localhost\\named_instance", database="db_name", port=12345)

# no port specified
creds = SqlCreds(server="localhost\\named_instance", database="db_name", port=None)
````

The port number can also be extracted from a SqlAlchemy connection provided the conditions above are met.