### PR TITLE
Added test for all delimiters

### DIFF
--- a/bcpandas/tests/test_to_sql.py
+++ b/bcpandas/tests/test_to_sql.py
@@ -16,7 +16,7 @@ import sys
 from typing import Optional, no_type_check
 
 from bcpandas import to_sql
-from bcpandas.constants import _DELIMITER_OPTIONS, _QUOTECHAR_OPTIONS, BCPandasValueError
+from bcpandas.constants import _DELIMITER_OPTIONS, _QUOTECHAR_OPTIONS, BCPandasValueError, NEWLINE
 from hypothesis import HealthCheck, given, settings
 import hypothesis.strategies as st
 import numpy as np


### PR DESCRIPTION
Added a test to make sure that the `to_sql` method uploads for every combination of ASCII character and delimiter.

The tests create DataFrames with characters 1-127 (chr 0 causes empty string challenges) excluding the delimiter and the first quoted identifier option.

The tests also perform some static asserts to make sure that the base range of options are covered.