### PR TITLE
pass 'stdin=DEVNULL' when running bcp

### DIFF
--- a/bcpandas/__init__.py
+++ b/bcpandas/__init__.py
@@ -6,7 +6,7 @@ from .main import SqlCreds, to_sql
 from .utils import bcp
 
 name = "bcpandas"
-__version__ = "0.7.1"
+__version__ = "1.0.1"
 
 
 # BCP check

--- a/bcpandas/__init__.py
+++ b/bcpandas/__init__.py
@@ -11,7 +11,7 @@ __version__ = "0.7.1"
 
 # BCP check
 try:
-    run(["bcp", "-v"], stdout=DEVNULL, stderr=DEVNULL)
+    run(["bcp", "-v"], stdout=DEVNULL, stderr=DEVNULL, stdin=DEVNULL)
 except FileNotFoundError:
     warnings.warn("BCP utility not installed or not found in PATH, bcpandas will not work!")
 


### PR DESCRIPTION
This is a speculative fix for an issue logged in https://github.com/rstudio/reticulate/issues/292.