### PR TITLE
ENH: add option for custom delim

### DIFF
--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -252,7 +252,7 @@ def to_sql(
         df = df.copy(deep=True).reset_index()
 
     # check if delimiter is ascii
-    if delim and not delim.isascii():
+    if delim and not len(delim) == len(delim.encode()):
         raise BCPandasValueError(
             f"Given delimiter {delim} is not ascii encodable"
         )

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -192,6 +192,7 @@ def to_sql(
     schema: str = "dbo",
     index: bool = True,
     if_exists: str = "fail",
+    delim: str = None,
     batch_size: int = None,
     debug: bool = False,
     bcp_path: str = None,
@@ -225,6 +226,8 @@ def to_sql(
         * append: Insert new values to the existing table. Matches the dataframe columns to the database columns by name.
             If the database table exists then the dataframe cannot have new columns that aren't in the table, 
             but conversely table columns can be missing from the dataframe.
+    delim: str, optional
+        Custom delimiter given by user, else it will fall back to preset delimiters.
     batch_size : int, optional
         Rows will be written in batches of this size at a time. By default, BCP sets this to 1000.
     debug : bool, default False
@@ -248,7 +251,13 @@ def to_sql(
     if index:
         df = df.copy(deep=True).reset_index()
 
-    delim = get_delimiter(df)
+    # check if delimiter is ascii
+    if delim and not delim.isascii():
+        raise BCPandasValueError(
+            f"Given delimiter {delim} is not ascii encodable"
+        )
+    else:
+        delim = get_delimiter(df)
     quotechar = get_quotechar(df)
 
     if batch_size is not None:

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -242,4 +242,3 @@ def run_cmd(cmd: List[str]) -> int:
         print(errs, end="")
         logger.error(errs)
     return proc.returncode
-

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -242,3 +242,4 @@ def run_cmd(cmd: List[str]) -> int:
         print(errs, end="")
         logger.error(errs)
     return proc.returncode
+


### PR DESCRIPTION
Option to add a custom delimiter, as long as it ASCII. This is better than allowing all ASCII characters.

Still to be tested, but opening this PR so you can have a look and comment.