### PR TITLE
Added support for MultiSubnetFailover

### DIFF
--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -63,11 +63,13 @@ class SqlCreds:
         password: Optional[str] = None,
         driver_version: int = 17,
         port: int = 1433,
+        useMultiSubnetFailover: bool = False,
         odbc_kwargs: Optional[Dict[str, Union[str, int]]] = None,
     ):
         self.server = server
         self.database = database
         self.port = port
+        self.useMultiSubnetFailover = useMultiSubnetFailover
 
         self.driver = f"{{ODBC Driver {driver_version} for SQL Server}}"
 
@@ -92,6 +94,9 @@ class SqlCreds:
             db_url += "Trusted_Connection=yes;"
 
         logger.info(f"Created creds:\t{self}")
+
+        if useMultiSubnetFailover:
+            db_url += ";MultiSubnetFailover=Yes;"
 
         # construct the engine for sqlalchemy
         if odbc_kwargs:

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -78,6 +78,10 @@ def bcp(
     else:
         sql_item_string = f"{schema}.{sql_item}"
 
+    server = creds.server
+    if creds.useMultiSubnetFailover:
+        server = f"'{server};MultiSubnetFailover=Yes;'"
+
     # construct BCP command
     bcp_command = [
         "bcp" if bcp_path is None else quote_this(str(bcp_path)),
@@ -85,7 +89,7 @@ def bcp(
         direc,
         flat_file,
         "-S",
-        creds.server,
+        server,
         "-d",
         creds.database,
         "-q",  # Executes the SET QUOTED_IDENTIFIERS ON statement, needed for Azure SQL DW


### PR DESCRIPTION
This is a small fix to allow enable/disable useMultiSubnetFailover.

In our production environment in order for BCP to connect to our database, the useMultiSubnetFailor option must be enabled.

This works for BCP version 17 and up.