### PR TITLE
Add engine as an optional param to SqlCreds

### DIFF
--- a/bcpandas/tests/test_sqlcreds.py
+++ b/bcpandas/tests/test_sqlcreds.py
@@ -179,7 +179,7 @@ def test_sql_creds_for_provided_engine():
     """
     Tests that when an engine is provided it is used
     """
-    # GIVEN an engine 
+    # GIVEN an engine
     mssql_engine = create_engine(
         "mssql+pyodbc://test_server_1/test_db_1?trusted_connection=yes&driver=ODBC+Driver+17+for+SQL+Server"
     )

--- a/bcpandas/tests/test_sqlcreds.py
+++ b/bcpandas/tests/test_sqlcreds.py
@@ -175,6 +175,24 @@ def test_sql_creds_for_windows_auth_blank_port():
     )
 
 
+def test_sql_creds_for_provided_engine():
+    """
+    Tests that when an engine is provided it is used
+    """
+    # GIVEN an engine 
+    mssql_engine = create_engine(
+        "mssql+pyodbc://test_server_1/test_db_1?trusted_connection=yes&driver=ODBC+Driver+17+for+SQL+Server"
+    )
+    # WHEN creds instatiated with this engine
+    creds = SqlCreds(
+        server="test_server_2",
+        database="test_db_2",
+        engine=mssql_engine,
+    )
+    # THEN the provided engine is used
+    assert creds.engine == mssql_engine
+
+
 def test_sql_creds_from_sqlalchemy():
     """
     Tests that the SqlCreds object can be created from a SqlAlchemy engine


### PR DESCRIPTION
### Context

I need to use an existing engine to instantiate SqlCreds as the engine has a set of non default options. The existing from engine method does not work for my URLs

### Change

* Added engine as an optional param to sql creds. If provided used instead of creating an engine

Maybe this could be handled in from_engine but feel like there is no nice way of retrieving the needed bcp params from an engine so it's good to have a fullback option.