### PR TITLE
Parametrized data format

### DIFF
--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -322,6 +322,11 @@ def to_sql(
     print_output: bool = True,
     delimiter: str = None,
     quotechar: str = None,
+    encoding: str = "65001",
+    data_type: str = "-c",
+    separator: str = ";",
+    use_format_file: bool = True 
+
 ):
     """
     Writes the pandas DataFrame to a SQL table or view.
@@ -455,6 +460,10 @@ def to_sql(
             schema=schema,
             batch_size=batch_size,
             bcp_path=bcp_path,
+            encoding=encoding,
+            data_type=data_type,
+            separator=separator,
+            use_format_file=use_format_file 
         )
     finally:
         if not debug:

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -324,7 +324,6 @@ def to_sql(
     quotechar: str = None,
     encoding: str = "65001",
     data_type: str = "-c",
-    separator: str = ";",
     use_format_file: bool = True,
 ):
     """
@@ -457,11 +456,11 @@ def to_sql(
             print_output=print_output,
             sql_type=sql_type,
             schema=schema,
+            col_delimiter=delim,
             batch_size=batch_size,
             bcp_path=bcp_path,
             encoding=encoding,
             data_type=data_type,
-            separator=separator,
             use_format_file=use_format_file,
         )
     finally:

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -325,8 +325,7 @@ def to_sql(
     encoding: str = "65001",
     data_type: str = "-c",
     separator: str = ";",
-    use_format_file: bool = True 
-
+    use_format_file: bool = True,
 ):
     """
     Writes the pandas DataFrame to a SQL table or view.
@@ -463,7 +462,7 @@ def to_sql(
             encoding=encoding,
             data_type=data_type,
             separator=separator,
-            use_format_file=use_format_file 
+            use_format_file=use_format_file,
         )
     finally:
         if not debug:

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -322,7 +322,7 @@ def to_sql(
     print_output: bool = True,
     delimiter: str = None,
     quotechar: str = None,
-    encoding: str = "65001",
+    encoding: str = None,
     data_type: str = "-c",
     use_format_file: bool = True,
 ):

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -109,7 +109,7 @@ def bcp(
             raise ValueError(
                 f"If not using format file, encoding is expected, expected type int or str, got: {type(encoding)}, value: {encoding}"
             )
-            
+
     elif direc in (OUT, QUERYOUT):
         bcp_command += [
             str(data_type),  # marking as character data, not Unicode (maybe make as param?)

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -47,7 +47,7 @@ def bcp(
     format_file_path: str = None,
     batch_size: int = None,
     col_delimiter: str = None,
-    encoding: str = "65001",
+    encoding: str = None,
     data_type: str = "-c",
     row_terminator: str = None,
     bcp_path: Union[str, Path] = None,
@@ -109,7 +109,7 @@ def bcp(
             raise ValueError(
                 f"If not using format file, encoding is expected, expected type int or str, got: {type(encoding)}, value: {encoding}"
             )
-
+            
     elif direc in (OUT, QUERYOUT):
         bcp_command += [
             str(data_type),  # marking as character data, not Unicode (maybe make as param?)

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -99,8 +99,10 @@ def bcp(
         bcp_command += ["-b", str(batch_size)]
 
     # formats
-    if data_type not in ("-c", "-w"):
-        raise ValueError(f"If not using format file, data_type sould be -c or -w, got: {data_type}")
+    if data_type not in ('-c','-w'):
+        raise ValueError(
+            f"data_type should be -c or -w, got: {data_type}"
+        )
 
     if direc == IN and use_format_file:
         bcp_command += ["-f", format_file_path]

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -99,6 +99,11 @@ def bcp(
         bcp_command += ["-b", str(batch_size)]
 
     # formats
+    if data_type not in ('-c','-w'):
+        raise ValueError(
+            f"If not using format file, data_type sould be -c or -w, got: {data_type}"
+        )
+
     if direc == IN and use_format_file:
         bcp_command += ["-f", format_file_path]
 

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -57,7 +57,6 @@ def bcp(
     See https://docs.microsoft.com/en-us/sql/tools/bcp-utility
     """
 
-
     combos = {TABLE: [IN, OUT], QUERY: [QUERYOUT], VIEW: [IN, OUT]}
     direc = direction.lower()
     # validation
@@ -107,7 +106,9 @@ def bcp(
         if encoding and col_delimiter:
             bcp_command += [str(data_type), "-C", str(encoding), "-t", quote_this(col_delimiter)]
         else:
-            raise ValueError(f'If not using format file, encoding is expected, expected type int or str, got: {type(encoding)}, value: {encoding}')
+            raise ValueError(
+                f"If not using format file, encoding is expected, expected type int or str, got: {type(encoding)}, value: {encoding}"
+            )
 
     elif direc in (OUT, QUERYOUT):
         bcp_command += [

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -47,9 +47,9 @@ def bcp(
     format_file_path: str = None,
     batch_size: int = None,
     col_delimiter: str = None,
-    encoding: str = "65001", # for utf-8
+    encoding: str = "65001",  # for utf-8
     data_type: str = "-c",
-    separator: str = ";", 
+    separator: str = ";",
     row_terminator: str = None,
     bcp_path: Union[str, Path] = None,
     use_format_file: bool = True,
@@ -100,14 +100,10 @@ def bcp(
 
     # formats
     if direc == IN and use_format_file:
-        bcp_command += [
-                        "-f", format_file_path] 
+        bcp_command += ["-f", format_file_path]
 
     elif direc == IN and not use_format_file:
-        bcp_command += [
-                        str(data_type), 
-                        "-C", str(encoding),
-                        "-t", quote_this(separator)] 
+        bcp_command += [str(data_type), "-C", str(encoding), "-t", quote_this(separator)]
 
     elif direc in (OUT, QUERYOUT):
         bcp_command += [
@@ -119,7 +115,6 @@ def bcp(
                 f"-r{read_data_settings['newline'] if row_terminator is None else row_terminator}"
             ),
         ]
-
 
     # execute
     bcp_command_log = [c if c != creds.password else "[REDACTED]" for c in bcp_command]
@@ -240,13 +235,12 @@ def run_cmd(cmd: List[str], *, print_output: bool) -> int:
     The exit code of the command
     """
 
-
     cmd = " ".join(cmd)  # type: ignore
     if IS_WIN32:
         with_shell = False
     else:
         with_shell = True
-        
+
     proc = Popen(
         cmd,
         stdout=PIPE,

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -99,10 +99,8 @@ def bcp(
         bcp_command += ["-b", str(batch_size)]
 
     # formats
-    if data_type not in ('-c','-w'):
-        raise ValueError(
-            f"data_type should be -c or -w, got: {data_type}"
-        )
+    if data_type not in ("-c", "-w"):
+        raise ValueError(f"data_type should be -c or -w, got: {data_type}")
 
     if direc == IN and use_format_file:
         bcp_command += ["-f", format_file_path]

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -244,10 +244,9 @@ def run_cmd(cmd: List[str], *, print_output: bool) -> int:
     cmd = " ".join(cmd)  # type: ignore
     if IS_WIN32:
         with_shell = False
-
     else:
         with_shell = True
-        cmd = " ".join(cmd)  # type: ignore
+        
     proc = Popen(
         cmd,
         stdout=PIPE,

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -47,6 +47,8 @@ def bcp(
     format_file_path: str = None,
     batch_size: int = None,
     col_delimiter: str = None,
+    encoding: str = "-C65001", # for utf-8
+    data_type: str = "-c", 
     row_terminator: str = None,
     bcp_path: Union[str, Path] = None,
 ):
@@ -99,7 +101,8 @@ def bcp(
         bcp_command += ["-f", format_file_path]
     elif direc in (OUT, QUERYOUT):
         bcp_command += [
-            "-c",  # marking as character data, not Unicode (maybe make as param?)
+            quote_this(data_type),  # marking as character data, not Unicode (maybe make as param?)
+            quote_this(encoding),
             quote_this(
                 f"-t{read_data_settings['delimiter'] if col_delimiter is None else col_delimiter}"
             ),

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -99,10 +99,8 @@ def bcp(
         bcp_command += ["-b", str(batch_size)]
 
     # formats
-    if data_type not in ('-c','-w'):
-        raise ValueError(
-            f"If not using format file, data_type sould be -c or -w, got: {data_type}"
-        )
+    if data_type not in ("-c", "-w"):
+        raise ValueError(f"If not using format file, data_type sould be -c or -w, got: {data_type}")
 
     if direc == IN and use_format_file:
         bcp_command += ["-f", format_file_path]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description="High-level wrapper around BCP for high performance data transfers between pandas and SQL Server. No knowledge of BCP required!!",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yehoshuadimarsky/bcpandas",
+    url="https://github.com/Kurdzik/bcpandas",
     packages=find_packages(),
     install_requires=["pandas>=0.19", "pyodbc", "sqlalchemy>=1.0"],
     python_requires=">=3.7",


### PR DESCRIPTION
Added few parameters to dcp and to_sql functions:

<li> encoding: str,  - takes encoding code page as an input (for utf-8 it is 65001)
<li> data_type: str  - argument used if use_format_file = False, here you can  specify what format should data take (-c, -w) 
<li> use_format_file: bool - specify if you want to use created format file or pass data type and encoding separately

