### PR TITLE
Allow to specify custom encoding for BCP data file

### DIFF
--- a/bcpandas/__init__.py
+++ b/bcpandas/__init__.py
@@ -1,8 +1,8 @@
 from subprocess import DEVNULL, run
 import warnings
 
-from bcpandas.main import SqlCreds, to_sql  # noqa: F401
-from bcpandas.utils import bcp  # noqa: F401
+from bcpandas.main import SqlCreds, to_sql
+from bcpandas.utils import bcp
 
 name = "bcpandas"
 __version__ = "2.0.0"

--- a/bcpandas/__init__.py
+++ b/bcpandas/__init__.py
@@ -15,3 +15,5 @@ except FileNotFoundError:
     warnings.warn("BCP utility not installed or not found in PATH, bcpandas will not work!")
 
 del run, DEVNULL, warnings
+
+__all__ = ["SqlCreds", "to_sql", "bcp"]

--- a/bcpandas/__init__.py
+++ b/bcpandas/__init__.py
@@ -1,8 +1,8 @@
 from subprocess import DEVNULL, run
 import warnings
 
-from bcpandas.main import SqlCreds, to_sql
-from bcpandas.utils import bcp
+from bcpandas.main import SqlCreds, to_sql  # noqa: F401
+from bcpandas.utils import bcp  # noqa: F401
 
 name = "bcpandas"
 __version__ = "2.0.0"

--- a/bcpandas/__init__.py
+++ b/bcpandas/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa F401
 from subprocess import DEVNULL, run
 import warnings
 

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -322,6 +322,7 @@ def to_sql(
     print_output: bool = True,
     delimiter: str = None,
     quotechar: str = None,
+    encoding: Optional[str] = None,
 ):
     """
     Writes the pandas DataFrame to a SQL table or view.
@@ -374,6 +375,8 @@ def to_sql(
         Optional delimiter to use, otherwise will use the result of `constants.get_delimiter`
     quotechar: str, default None
         Optional quotechar to use, otherwise will use the result of `constants.get_quotechar`
+    encoding: str, default None
+        Optional encoding to use for writing the BCP data-file. Defaults to `utf-8`.
 
     Notes
     -----
@@ -406,6 +409,7 @@ def to_sql(
         line_terminator=NEWLINE,
         doublequote=True,
         escapechar=None,  # not needed, as using doublequote
+        encoding=encoding,
     )
     logger.debug(f"Saved dataframe to temp CSV file at {csv_file_path}")
 


### PR DESCRIPTION
# Motivation

The BCP data-file is always written with UTF-8 encoding. In our case, this is not actually desired and we would rather opt for `iso-8859-1`. This PR allows the user to configure the encoding.
