### PR TITLE
Allow to manually specify work directory for temporary files

### DIFF
--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -7,6 +7,7 @@ Created on Sat Aug  3 23:07:15 2019
 import csv
 import logging
 import os
+from pathlib import Path
 from textwrap import dedent
 from typing import Dict, Optional, Union
 from urllib.parse import quote_plus
@@ -324,6 +325,7 @@ def to_sql(
     delimiter: Optional[str] = None,
     quotechar: Optional[str] = None,
     encoding: Optional[str] = None,
+    work_directory: Optional[Path] = None,
 ):
     """
     Writes the pandas DataFrame to a SQL table or view.
@@ -381,6 +383,9 @@ def to_sql(
         Optional quotechar to use, otherwise will use the result of `constants.get_quotechar`
     encoding: str, default None
         Optional encoding to use for writing the BCP data-file. Defaults to `utf-8`.
+    work_directory: pathlib.Path, default None
+        Optional directory where temporary files are written to. If not provided, defaults to the
+        system-default for temporary files.
 
     Notes
     -----
@@ -401,7 +406,7 @@ def to_sql(
     _quotechar = get_quotechar(df) if quotechar is None else quotechar
 
     # save to temp path
-    csv_file_path = get_temp_file()
+    csv_file_path = get_temp_file(work_directory)
     # replace bools with 1 or 0, this is what pandas native does when writing to SQL Server
     df.replace({True: 1, False: 0}).to_csv(
         path_or_buf=csv_file_path,
@@ -418,7 +423,7 @@ def to_sql(
     logger.debug(f"Saved dataframe to temp CSV file at {csv_file_path}")
 
     # build format file
-    fmt_file_path = get_temp_file()
+    fmt_file_path = get_temp_file(work_directory)
 
     sql_item_exists = _sql_item_exists(
         sql_type=sql_type, schema=schema, table_name=table_name, creds=creds

--- a/bcpandas/tests/test_to_sql.py
+++ b/bcpandas/tests/test_to_sql.py
@@ -284,6 +284,22 @@ def test_use_tablock_param(sql_creds):
     assert sql_creds.engine.execute("SELECT * FROM some_table").first()[0] == 1.5
 
 
+def test_custom_work_directory(sql_creds):
+    """
+    Test the work directory parameters.
+    """
+    to_sql(
+        df=pd.DataFrame({"col1": [1.5]}),
+        table_name="some_table",
+        creds=sql_creds,
+        if_exists="replace",
+        index=False,
+        sql_type="table",
+        work_directory=Path("."),
+    )
+    assert sql_creds.engine.execute("SELECT * FROM some_table").first()[0] == 1.5
+
+
 @pytest.mark.usefixtures("database")
 class _BaseToSql:
     sql_type = "table"

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -5,7 +5,6 @@ Created on Sat Aug  3 23:07:15 2019
 """
 
 import logging
-import os
 from pathlib import Path
 import random
 import shlex
@@ -39,12 +38,12 @@ logger = logging.getLogger(__name__)
 def bcp(
     sql_item: str,
     direction: str,
-    flat_file: str,
+    flat_file: Path,
     creds,
     print_output: bool,
     sql_type: str = "table",
     schema: str = "dbo",
-    format_file_path: Optional[str] = None,
+    format_file_path: Optional[Path] = None,
     batch_size: Optional[int] = None,
     use_tablock: bool = False,
     col_delimiter: Optional[str] = None,
@@ -84,7 +83,7 @@ def bcp(
         "bcp" if bcp_path is None else quote_this(str(bcp_path)),
         sql_item_string,
         direc,
-        flat_file,
+        str(flat_file),
         "-S",
         creds.server,
         "-d",
@@ -100,7 +99,7 @@ def bcp(
 
     # formats
     if direc == IN:
-        bcp_command += ["-f", format_file_path]
+        bcp_command += ["-f", str(format_file_path)]
     elif direc in (OUT, QUERYOUT):
         bcp_command += [
             "-c",  # marking as character data, not Unicode (maybe make as param?)
@@ -120,15 +119,15 @@ def bcp(
         raise BCPandasException(f"Bcp command failed with exit code {ret_code}")
 
 
-def get_temp_file() -> str:
+def get_temp_file(directory: Optional[Path] = None) -> Path:
     """
     Returns full path to a temporary file without creating it.
     """
-    tmp_dir = tempfile.gettempdir()
-    file_path = os.path.join(
-        tmp_dir, "".join(random.choices(string.ascii_letters + string.digits, k=21))
-    )
-    return file_path
+    if directory is None:
+        tmp_dir = Path(tempfile.gettempdir())
+    else:
+        tmp_dir = directory
+    return tmp_dir / "".join(random.choices(string.ascii_letters + string.digits, k=21))
 
 
 def _escape(input_string: str) -> str:


### PR DESCRIPTION
# Motivation

In some instances, the system-wide temporary directory is not an ideal place to put data files as they might become too big.

Thus, this PR allows to manually specify the directory where data files ought to be put.