### PR TITLE
Pass format file only if available

### DIFF
--- a/bcpandas/tests/test_utils.py
+++ b/bcpandas/tests/test_utils.py
@@ -39,8 +39,6 @@ def test_bcpandas_creates_command_without_port_if_default(run_cmd):
             "me",
             "-P",
             "secret",
-            "-f",
-            None,
         ],
         print_output=True,
     )
@@ -72,8 +70,6 @@ def test_bcpandas_creates_command_with_port_if_not_default(run_cmd):
             "me",
             "-P",
             "secret",
-            "-f",
-            None,
         ],
         print_output=True,
     )

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -103,7 +103,7 @@ def bcp(
         bcp_command += ["-h", "TABLOCK"]
 
     # formats
-    if direc == IN:
+    if direc == IN and format_file_path is not None:
         bcp_command += ["-f", str(format_file_path)]
     elif direc in (OUT, QUERYOUT):
         bcp_command += [


### PR DESCRIPTION
The format file is currently passed to `bcp` always, even if the path is `None`. Let's fix this.