### PR TITLE
Include failure details in bcp exceptions

### DIFF
--- a/bcpandas/constants.py
+++ b/bcpandas/constants.py
@@ -6,12 +6,15 @@ Created on Sat Aug  3 23:20:19 2019
 
 import os
 import sys
+from typing import List, Optional
 
 import pandas as pd
 
 
 class BCPandasException(Exception):
-    pass
+    def __init__(self, message: str, details: Optional[List[str]] = None):
+        super().__init__(message)
+        self.details = details or []
 
 
 class BCPandasValueError(BCPandasException):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ bcpandas = "bcpandas.main:to_sql"
 pandas = ">=0.19"
 pyodbc = "*"
 python = ">=3.8.1"
-sqlalchemy = ">=1.0"
+sqlalchemy = ">=1.0,<2.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "22.12.0"

--- a/tests/test_to_sql.py
+++ b/tests/test_to_sql.py
@@ -802,4 +802,4 @@ def test_bcp_login_failure(sql_creds: SqlCreds):
         to_sql(df=df, table_name="tbl_login_failure", creds=wrong_sql_creds, if_exists="replace")
         pytest.fail("to_sql is not expected to succeed")
     except BCPandasException as e:
-        assert any("login" in message for message in e.details)
+        assert any("Login failed" in message for message in e.details)

--- a/tests/test_to_sql.py
+++ b/tests/test_to_sql.py
@@ -23,13 +23,8 @@ from pandas.testing import assert_frame_equal
 import pytest
 import sqlalchemy
 
-from bcpandas import SqlCreds, to_sql
-from bcpandas.constants import (
-    _DELIMITER_OPTIONS,
-    _QUOTECHAR_OPTIONS,
-    BCPandasException,
-    BCPandasValueError,
-)
+from bcpandas import to_sql
+from bcpandas.constants import _DELIMITER_OPTIONS, _QUOTECHAR_OPTIONS, BCPandasValueError
 
 from .utils import (
     assume_not_all_delims_and_quotechars,
@@ -787,19 +782,3 @@ class TestToSqlOther(_BaseToSql):
     @settings(deadline=None)
     def test_df_dates(self, df, sql_creds, index):
         self._test_df_template(df, sql_creds, index)
-
-
-@pytest.mark.usefixtures("database")
-def test_bcp_login_failure(sql_creds: SqlCreds):
-    wrong_sql_creds = SqlCreds(
-        server=sql_creds.server,
-        database=sql_creds.database,
-        username=sql_creds.username,
-        password="mywrongpassword",
-    )
-    df = pd.DataFrame([{"col1": "value"}])
-    try:
-        to_sql(df=df, table_name="tbl_login_failure", creds=wrong_sql_creds, if_exists="replace")
-        pytest.fail("to_sql is not expected to succeed")
-    except BCPandasException as e:
-        assert any("Login failed" in message for message in e.details)

--- a/tests/test_to_sql.py
+++ b/tests/test_to_sql.py
@@ -23,8 +23,13 @@ from pandas.testing import assert_frame_equal
 import pytest
 import sqlalchemy
 
-from bcpandas import to_sql
-from bcpandas.constants import _DELIMITER_OPTIONS, _QUOTECHAR_OPTIONS, BCPandasValueError
+from bcpandas import SqlCreds, to_sql
+from bcpandas.constants import (
+    _DELIMITER_OPTIONS,
+    _QUOTECHAR_OPTIONS,
+    BCPandasException,
+    BCPandasValueError,
+)
 
 from .utils import (
     assume_not_all_delims_and_quotechars,
@@ -782,3 +787,19 @@ class TestToSqlOther(_BaseToSql):
     @settings(deadline=None)
     def test_df_dates(self, df, sql_creds, index):
         self._test_df_template(df, sql_creds, index)
+
+
+@pytest.mark.usefixtures("database")
+def test_bcp_login_failure(sql_creds: SqlCreds):
+    wrong_sql_creds = SqlCreds(
+        server=sql_creds.server,
+        database=sql_creds.database,
+        username=sql_creds.username,
+        password="mywrongpassword",
+    )
+    df = pd.DataFrame([{"col1": "value"}])
+    try:
+        to_sql(df=df, table_name="tbl_login_failure", creds=wrong_sql_creds, if_exists="replace")
+        pytest.fail("to_sql is not expected to succeed")
+    except BCPandasException as e:
+        assert any("login" in message for message in e.details)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,3 +102,4 @@ def test_bcp_login_failure(sql_creds: SqlCreds):
             pytest.fail("utils.bcp is not expected to succeed")
         except BCPandasException as e:
             assert any("Login failed" in message for message in e.details)
+            assert not any("not a real error" in message for message in e.details)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from bcpandas.constants import IN, BCPandasException
 
 @pytest.fixture(name="run_cmd")
 def fixture_run_cmd_capture(monkeypatch):
-    run_cmd = mock.MagicMock(return_value=0)
+    run_cmd = mock.MagicMock(return_value=(0, []))
     monkeypatch.setattr(utils, "run_cmd", run_cmd)
     return run_cmd
 


### PR DESCRIPTION
# Motivation

When `bcp` fails, `bcpandas` only raises an exception with the hint that the command failed with exit code 1 (typically, at least), which is not particularly telling. In order to allow control flows based on the actual error, this PR updates the `bcp` execution to include some error details in case of failure.