### PR TITLE
Fully Redact Password

### DIFF
--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -114,11 +114,7 @@ class SqlCreds:
             db_url += ";".join(f"{k}={v}" for k, v in odbc_kwargs.items())
         conn_string = f"mssql+pyodbc:///?odbc_connect={quote_plus(db_url)}"
         self.engine = sa.engine.create_engine(conn_string)
-<<<<<<< HEAD
         engine_msg = sub('PWD%3D.*%3B', 'PWD%3D[REDACTED]%3B', str(self.engine))
-=======
-        engine_msg = sub(r"PWD\%3D.*\%3B", "PWD%3D[REDACTED]\%3B", str(self.engine))
->>>>>>> a666b1c6e24aec978158a206e35768fb2ededab9
 
         logger.info(f"Created engine for sqlalchemy:\t{engine_msg}")
 

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -114,7 +114,7 @@ class SqlCreds:
             db_url += ";".join(f"{k}={v}" for k, v in odbc_kwargs.items())
         conn_string = f"mssql+pyodbc:///?odbc_connect={quote_plus(db_url)}"
         self.engine = sa.engine.create_engine(conn_string)
-        engine_msg = sub('PWD%3D.*%3B', 'PWD%3D[REDACTED]%3B', str(self.engine))
+        engine_msg = sub("PWD%3D.*%3B", "PWD%3D[REDACTED]%3B", str(self.engine))
 
         logger.info(f"Created engine for sqlalchemy:\t{engine_msg}")
 

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -114,7 +114,7 @@ class SqlCreds:
             db_url += ";".join(f"{k}={v}" for k, v in odbc_kwargs.items())
         conn_string = f"mssql+pyodbc:///?odbc_connect={quote_plus(db_url)}"
         self.engine = sa.engine.create_engine(conn_string)
-        engine_msg = sub(r'PWD\%3D.*\%3B', 'PWD%3D[REDACTED]\%3B', str(self.engine))
+        engine_msg = sub('PWD%3D.*%3B', 'PWD%3D[REDACTED]%3B', str(self.engine))
 
         logger.info(f"Created engine for sqlalchemy:\t{engine_msg}")
 

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -13,6 +13,7 @@ import string
 from subprocess import PIPE, STDOUT, Popen
 import tempfile
 from typing import Dict, List, Optional, Tuple, Union
+from re import sub
 
 import pandas as pd
 
@@ -124,8 +125,9 @@ def bcp(
         ]
 
     # execute
-    bcp_command_log = [c if c != creds.password else "[REDACTED]" for c in bcp_command]
-    logger.info(f"Executing BCP command now... \nBCP command is: {bcp_command_log}")
+    bcp_command_log = ", ".join(bcp_command)
+    bcp_command_log_msg = sub(r'-P,\s.*,',"-P, [REDACTED],",bcp_command_log)
+    logger.info(f"Executing BCP command now... \nBCP command is: {bcp_command_log_msg}")
     ret_code, output = run_cmd(bcp_command, print_output=print_output)
     if ret_code != 0:
         raise BCPandasException(

--- a/tests/test_sqlcreds.py
+++ b/tests/test_sqlcreds.py
@@ -366,13 +366,15 @@ def test_sql_creds_from_sqlalchemy_windows_auth_blank_port():
     assert str(creds.engine.url) == _quote_engine_url(
         "Driver={ODBC Driver 99 for SQL Server};Server=tcp:test_server;Database=test_database"
     )
+
+
 @pytest.fixture(autouse=True)
 def test_sql_creds_for_username_password_logs_redacted(caplog):
     """
     Tests that the SqlCreds object does not info log the password in plain text
     """
     caplog.set_level(logging.INFO)
-    creds = SqlCreds(
+    SqlCreds(
         server="test_server",
         database="test_database",
         username="test_user",
@@ -382,6 +384,7 @@ def test_sql_creds_for_username_password_logs_redacted(caplog):
     info = caplog.text
     assert "test_password" not in info
     assert "%3BPWD%3D[REDACTED]%3B" in info
+
 
 @pytest.mark.usefixtures("database")
 def test_sqlcreds_connection(sql_creds):

--- a/tests/test_sqlcreds.py
+++ b/tests/test_sqlcreds.py
@@ -368,7 +368,6 @@ def test_sql_creds_from_sqlalchemy_windows_auth_blank_port():
     )
 
 
-@pytest.fixture(autouse=True)
 def test_sql_creds_for_username_password_logs_redacted(caplog):
     """
     Tests that the SqlCreds object does not info log the password in plain text


### PR DESCRIPTION
In main.py
- line 108: there was actually no problem here in my current environment, but this seems like a safe bet, just in case
- line 116: The url encoded connection string is currently logging the password in plain text between encodings. This change will redact passwords in a connection string message variable to be logged. 

In utils.py
- line 127: in a linux environment, if a special character is in the password, the quote_this function will put the password in double quotes and single quotes. So, the ```password``` becomes ```'password'``` and this line fails to redact the password
- line 128: will log the non-redacted password in the case mentioned for 127

The solution in all cases:
- using regular expressions to redact a password from the url_encoded connection string and two other places, to ensure password is redacted from logs