### PR TITLE
Add collation parameter

### DIFF
--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -342,7 +342,7 @@ def to_sql(
     quotechar: Optional[str] = None,
     encoding: Optional[str] = None,
     work_directory: Optional[Path] = None,
-    collation: Optional[str] = sql_collation,
+    collation: str = sql_collation,
 ):
     """
     Writes the pandas DataFrame to a SQL table or view.

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -25,7 +25,7 @@ from bcpandas.constants import (
     TABLE,
     BCPandasValueError,
     get_delimiter,
-    get_quotechar,
+    get_quotechar, sql_collation,
 )
 from bcpandas.utils import bcp, build_format_file, get_temp_file
 
@@ -342,6 +342,7 @@ def to_sql(
     quotechar: Optional[str] = None,
     encoding: Optional[str] = None,
     work_directory: Optional[Path] = None,
+    collation: Optional[str] = sql_collation,
 ):
     """
     Writes the pandas DataFrame to a SQL table or view.
@@ -453,7 +454,7 @@ def to_sql(
         if_exists=if_exists,
     )
 
-    fmt_file_txt = build_format_file(df=df, delimiter=delim, db_cols_order=cols_dict)
+    fmt_file_txt = build_format_file(df=df, delimiter=delim, db_cols_order=cols_dict, collation=collation)
     with open(fmt_file_path, "w") as ff:
         ff.write(fmt_file_txt)
     logger.debug(f"Created BCP format file at {fmt_file_path}")

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -160,7 +160,7 @@ def _escape(input_string: str) -> str:
 
 
 def build_format_file(
-    df: pd.DataFrame, delimiter: str, db_cols_order: Optional[Dict[str, int]] = None
+    df: pd.DataFrame, delimiter: str, db_cols_order: Optional[Dict[str, int]] = None, collation: str = sql_collation
 ) -> str:
     """
     Creates the non-xml SQL format file. Puts 4 spaces between each section.
@@ -179,6 +179,8 @@ def build_format_file(
         Maps existing columns in the database to their ordinal position, i.e. the order of the columns in the db table.
         1-indexed, so the first columns is 1, second is 2, etc.
         Only needed if the order of the columns in the dataframe doesn't match the database.
+    collation: str, optional
+        Collation to be used in the format file. The default value is 'SQL_Latin1_General_CP1_CI_AS'
 
     Returns
     -------
@@ -200,7 +202,7 @@ def build_format_file(
                     col_num if not db_cols_order else db_cols_order[str(col_name)]
                 ),  # Server column order
                 str(col_name),  # Server column name, optional as long as not blank
-                sql_collation,  # Column collation
+                collation,  # Column collation
                 "\n",
             ]
         )


### PR DESCRIPTION
Sometimes we need to insert into database strings with Unicode symbols or strings with non latin alphabet.
Unfortunately default collation "SQL_Latin1_General_CP1_CI_AS" can't process this cases. To solve this issue we may give to user an option to provide specific collation for his data.

This implementation assume one collation for whole dataframe.