### PR TITLE
Add option to specify the path of the error file

### DIFF
--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -346,7 +346,7 @@ def to_sql(
     batch_size: Optional[int] = None,
     use_tablock: bool = False,
     debug: bool = False,
-    bcp_path: Optional[str] = None,
+    bcp_path: Optional[Union[str, Path]] = None,
     dtype: Optional[dict] = None,
     process_dest_table: bool = True,
     print_output: bool = True,
@@ -356,7 +356,7 @@ def to_sql(
     work_directory: Optional[Path] = None,
     collation: str = sql_collation,
     identity_insert: bool = False,
-    err_file: Optional[Path] = None,
+    err_file: Optional[Union[str, Path]] = None,
 ):
     """
     Writes the pandas DataFrame to a SQL table or view.
@@ -395,7 +395,7 @@ def to_sql(
         Setting this option allows for larger batch sizes.
     debug : bool, default False
         If True, will not delete the temporary CSV and format files, and will output their location.
-    bcp_path : str, default None
+    bcp_path : str, pathlib.Path, default None
         The full path to the BCP utility, useful if it is not in the PATH environment variable
     dtype: dict, default None
         A dict with keys the names of columns and values SqlAlchemy types for defining their types. These are
@@ -419,7 +419,7 @@ def to_sql(
         system-default for temporary files.
     identity_insert: bool, default False
         Specifies that identity value or values in the imported data file are to be used for the identity column.
-    err_file: pathlib.Path, default None
+    err_file: str, pathlib.Path, default None
         Specifies the full path of an error file used to store any rows that the bcp utility can't transfer from
         the file to the database. Error messages from the bcp command go to the workstation of the user.
         If this option isn't used, an error file isn't created.

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -508,6 +508,7 @@ def to_sql(
             use_tablock=use_tablock,
             bcp_path=bcp_path,
             identity_insert=identity_insert,
+            err_file=err_file,
         )
     finally:
         if not debug:

--- a/bcpandas/main.py
+++ b/bcpandas/main.py
@@ -356,6 +356,7 @@ def to_sql(
     work_directory: Optional[Path] = None,
     collation: str = sql_collation,
     identity_insert: bool = False,
+    err_file: Optional[Path] = None,
 ):
     """
     Writes the pandas DataFrame to a SQL table or view.
@@ -418,6 +419,10 @@ def to_sql(
         system-default for temporary files.
     identity_insert: bool, default False
         Specifies that identity value or values in the imported data file are to be used for the identity column.
+    err_file: pathlib.Path, default None
+        Specifies the full path of an error file used to store any rows that the bcp utility can't transfer from
+        the file to the database. Error messages from the bcp command go to the workstation of the user.
+        If this option isn't used, an error file isn't created.
 
     Notes
     -----

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -52,6 +52,7 @@ def bcp(
     row_terminator: Optional[str] = None,
     bcp_path: Optional[Union[str, Path]] = None,
     identity_insert: bool = False,
+    err_file: Optional[Path] = None
 ):
     """
     See https://docs.microsoft.com/en-us/sql/tools/bcp-utility
@@ -113,6 +114,9 @@ def bcp(
 
     if identity_insert:
         bcp_command += ["-E"]
+
+    if err_file:
+        bcp_command += ["-e", str(err_file.resolve())]
 
     # formats
     if direc == IN and format_file_path is not None:

--- a/bcpandas/utils.py
+++ b/bcpandas/utils.py
@@ -52,7 +52,7 @@ def bcp(
     row_terminator: Optional[str] = None,
     bcp_path: Optional[Union[str, Path]] = None,
     identity_insert: bool = False,
-    err_file: Optional[Path] = None
+    err_file: Optional[Union[str, Path]] = None,
 ):
     """
     See https://docs.microsoft.com/en-us/sql/tools/bcp-utility
@@ -116,7 +116,7 @@ def bcp(
         bcp_command += ["-E"]
 
     if err_file:
-        bcp_command += ["-e", str(err_file.resolve())]
+        bcp_command += ["-e", str(err_file)]
 
     # formats
     if direc == IN and format_file_path is not None:


### PR DESCRIPTION
This change enables the use of the `-e` option for `bcp` (https://learn.microsoft.com/en-us/sql/tools/bcp-utility?view=sql-server-ver16#-e-err_file). This allows the creation of error files that contain detailed information about the rows that the `bcp` command couldn't process for whatever reason when executed.