### PR TITLE
When testing that 'bcp' can be run, also catch PermissionError.

### DIFF
--- a/bcpandas/__init__.py
+++ b/bcpandas/__init__.py
@@ -16,7 +16,7 @@ except Exception:
 # BCP check
 try:
     run(["bcp", "-v"], stdout=DEVNULL, stderr=DEVNULL, stdin=DEVNULL)
-except FileNotFoundError:
+except (FileNotFoundError, PermissionError):
     warnings.warn("BCP utility not installed or not found in PATH, bcpandas will not work!")
 
 del run, DEVNULL, warnings


### PR DESCRIPTION
In some environments you get that exception type, rather than FileNotFoundError, when there is no such executable.